### PR TITLE
Add search using IMDB ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegram-bot",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "With this bot you won't skip the moment when your favorite movies are available on the torrents!",
   "author": "Dmitrii Baranov",
   "scripts": {

--- a/src/controllers/search/index.ts
+++ b/src/controllers/search/index.ts
@@ -15,7 +15,7 @@ const searcher = new Scene('search');
 searcher.enter(async (ctx: ContextMessageUpdate) => {
   logger.debug(ctx, 'Enter search scene');
   const { backKeyboard } = getBackKeyboard(ctx);
-  await ctx.reply(ctx.i18n.t('scenes.search.welcome_to_search'), backKeyboard);
+  await ctx.replyWithHTML(ctx.i18n.t('scenes.search.welcome_to_search'), backKeyboard);
 });
 searcher.leave(async (ctx: ContextMessageUpdate) => {
   logger.debug(ctx, 'Leaves search scene');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,7 +26,7 @@
       "add_button": "➕ Add",
       "reason_movie_released": "🔔 This movie has been already released.",
       "reason_already_observing": "🚫You're already observing this movie.",
-      "welcome_to_search": "🚀 Activating search engine! Just type the title in and let's go!\n\nDon't forget that if you need more relevant results, you can specify a year in square brackets like this: star wars [2003]",
+      "welcome_to_search": "🚀 Activating search engine! Just type the title in and let's go!\n\nDon't forget that if you need more relevant results, you can specify a year in square brackets like this: <code>star wars [2003]</code> or you can paste an IMDB_ID in this format: <code>tt5433138</code>",
       "no_movies_found": "🗑 No movies were found... Try to specify your request"
     },
     "settings": {

--- a/src/util/movie-search.ts
+++ b/src/util/movie-search.ts
@@ -13,6 +13,7 @@ export interface ISearchResult {
   title: string;
   year: number;
   posterUrl: string;
+  filter: boolean;
 }
 
 type Provider = (params: ISearchParameters) => Promise<ISearchResult[]>;
@@ -38,7 +39,10 @@ const movieSearchWrapper = (provider: Provider) => async (ctx: ContextMessageUpd
     language
   });
 
-  const filteredResult = rawResult.filter(movie => movie.year >= currentYear - MOVIE_TTL);
+  let filteredResult = rawResult;
+  if (rawResult[0] && rawResult[0].filter == true) {
+    filteredResult = rawResult.filter(movie => movie.year >= currentYear - MOVIE_TTL);
+  }
 
   logger.debug(
     ctx,

--- a/src/util/search-providers/filmopotok.ts
+++ b/src/util/search-providers/filmopotok.ts
@@ -23,6 +23,7 @@ export async function filmopotok(params: ISearchParameters): Promise<ISearchResu
       id: item.slug.slice(0, 40), // Telegram can't pass more than 64 bytes as a callback data
       title: item.value,
       year: item.label.match(/> \((\d{4})/)[1],
-      posterUrl: item.label.match(/http:\/\/.*"/g)[0].slice(0, -1)
+      posterUrl: item.label.match(/http:\/\/.*"/g)[0].slice(0, -1),
+      filter: true
     }));
 }

--- a/src/util/search-providers/imdb.ts
+++ b/src/util/search-providers/imdb.ts
@@ -14,7 +14,7 @@ const IMDB_SEARCH_PARAMS = {
 export async function imdb(params: ISearchParameters): Promise<ISearchResult[]> {
 
   try {
-    const imdbID = /([tt])\w+/;
+    const imdbID = /[t]{2}[0-9]+/;
     if (imdbID.exec(params.title)) {
       let findById = await imdbAPI.get({ id: params.title }, IMDB_SEARCH_PARAMS);
       return [

--- a/src/util/search-providers/imdb.ts
+++ b/src/util/search-providers/imdb.ts
@@ -18,7 +18,13 @@ export async function imdb(params: ISearchParameters): Promise<ISearchResult[]> 
     if (imdbID.exec(params.title)) {
       let findById = await imdbAPI.get({ id: params.title }, IMDB_SEARCH_PARAMS);
       return [
-        { id: findById.imdbid, title: findById.title, year: findById.year, posterUrl: findById.poster }
+        {
+          id: findById.imdbid,
+          title: findById.title,
+          year: findById.year,
+          posterUrl: findById.poster,
+          filter: false
+        }
       ];
     } else {
       let search = await imdbAPI.search({ name: params.title, year: params.year }, IMDB_SEARCH_PARAMS);
@@ -26,7 +32,8 @@ export async function imdb(params: ISearchParameters): Promise<ISearchResult[]> 
         id: item.imdbid,
         title: item.title,
         year: item.year,
-        posterUrl: item.poster
+        posterUrl: item.poster,
+        filter: true
       }));
     }
 


### PR DESCRIPTION
```log
[Node] [2021-10-10T14:49:06.292Z] [error]: Error occurred during imdb searching for movie { title: 'f9', year: undefined, language: 'en' }. ImdbError { message: 'Too many results.: f9', name: 'imdb api error' }
```

When searching for generic movie names such as F9, cannot find the actual movie. 

Add a regex to check for [tt5433138](https://www.imdb.com/title/tt5433138/) IMDB ids to directly link to the IMDB movie.