### PR TITLE
Remove duplicates from API

### DIFF
--- a/src/util/movie-search.ts
+++ b/src/util/movie-search.ts
@@ -39,9 +39,9 @@ const movieSearchWrapper = (provider: Provider) => async (ctx: ContextMessageUpd
     language
   });
 
-  let filteredResult = rawResult;
+  let filteredResult = rawResult.filter((v,i,a)=>a.findIndex(t=>(t.id === v.id))===i);
   if (rawResult[0] && rawResult[0].filter == true) {
-    filteredResult = rawResult.filter(movie => movie.year >= currentYear - MOVIE_TTL);
+    filteredResult = filteredResult.filter(movie => movie.year >= currentYear - MOVIE_TTL);
   }
 
   logger.debug(


### PR DESCRIPTION
Somehow IMDB returns duplicated results with the same ID. 

Use ID to remove duplicated results. Does not affect search with different IDs

![image](https://user-images.githubusercontent.com/24467184/136768450-d35050f7-1a91-4a11-8c87-abbcf67e9a59.png)
